### PR TITLE
MPLUG-58- Resync: Large tables loses alarms

### DIFF
--- a/plugin/src/main/java/org/opennms/resync/TriggerService.java
+++ b/plugin/src/main/java/org/opennms/resync/TriggerService.java
@@ -200,15 +200,11 @@ public class TriggerService {
         parameters.putAll(config.getValue().getParameters());
         parameters.putAll(request.getParameters());
 
-
-        // TODO: This excepts on duplicate session? Should we wait?
-
         return this.snmpClient.walk(agent, new AlarmTableTracker(config.getValue()))
                 .withDescription("resync-get")
                 .execute()
                 .thenAccept(tracker -> {
-
-                    // TODO: need better to create the session in get scenario
+                    // TODO: This excepts on duplicate session? Should we wait?
                     this.eventHandler.createSession(EventHandler.Source.builder()
                                     .nodeId(node.getId().longValue())
                                     .iface(iface.getIpAddress())

--- a/plugin/src/main/java/org/opennms/resync/TriggerService.java
+++ b/plugin/src/main/java/org/opennms/resync/TriggerService.java
@@ -200,18 +200,22 @@ public class TriggerService {
         parameters.putAll(config.getValue().getParameters());
         parameters.putAll(request.getParameters());
 
-        this.eventHandler.createSession(EventHandler.Source.builder()
-                        .nodeId(node.getId().longValue())
-                        .iface(iface.getIpAddress())
-                        .build(),
-                request.sessionId,
-                parameters);
+
         // TODO: This excepts on duplicate session? Should we wait?
 
         return this.snmpClient.walk(agent, new AlarmTableTracker(config.getValue()))
                 .withDescription("resync-get")
                 .execute()
                 .thenAccept(tracker -> {
+
+                    // TODO: need better to create the session in get scenario
+                    this.eventHandler.createSession(EventHandler.Source.builder()
+                                    .nodeId(node.getId().longValue())
+                                    .iface(iface.getIpAddress())
+                                    .build(),
+                            request.sessionId,
+                            parameters);
+
                     this.eventForwarder.sendNowSync(new EventBuilder()
                             .setTime(new Date())
                             .setSource(EVENT_SOURCE)


### PR DESCRIPTION
In large alarm tables, there are lost alarms. This is only happening on GET method.

 

Things start to fall apart with 1000. Target to support is 10k alarms from a single system.