### PR TITLE
MPLUG-65Resync: Make CI pipeline / tests work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Run integration tests
           command: |
-            mvn -DskipITs=false -DskipTests=false clean install test integration-test
+            mvn -DskipITs=false -DskipTests=false install test integration-test
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run:
           name: Run integration tests
           command: |
-            mvn -DskipITs=false -DskipTests=false install test integration-test
+            mvn -DskipITs=false -DskipTests=false clean install test integration-test
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ commands:
             name: git clone
             command: |
               git clone  "https://github.com/OpenNMS/opennms.git" ~/opennms
+              cd ~/opennms
+              git checkout opennms-33.0.10-1
+              cd -
               #if [ -n "${CIRCLE_TAG}" ]; then
               #  git checkout --force "${CIRCLE_TAG}"
               #  git reset --hard "${CIRCLE_SHA1}"

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -11,13 +11,13 @@
         <feature dependency="true">opennms-snmp</feature>
         <feature dependency="true">opennms-config-api</feature>
         <feature dependency="true">opennms-config-impl</feature>
-
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.lib/${opennms.version}</bundle>
         <bundle dependency="true">mvn:org.apache.commons/commons-jexl3/${jexl.version}</bundle>
 
         <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/${metrics.version}</bundle>
 
         <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.1.1</bundle>
-        <bundle dependency="true">mvn:com.google.guava/guava/29.0-jre</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/32.0.1-jre</bundle>
         <bundle dependency="true">mvn:com.google.code.gson/gson/2.11.0</bundle>
 
         <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -17,7 +17,7 @@
         <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/${metrics.version}</bundle>
 
         <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.1.1</bundle>
-        <bundle dependency="true">mvn:com.google.guava/guava/${google.guava.version}</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/29.0-jre</bundle>
         <bundle dependency="true">mvn:com.google.code.gson/gson/2.11.0</bundle>
 
         <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -17,7 +17,7 @@
         <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/${metrics.version}</bundle>
 
         <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.1.1</bundle>
-        <bundle dependency="true">mvn:com.google.guava/guava/32.0.1-jre</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/${google.guava.version}</bundle>
         <bundle dependency="true">mvn:com.google.code.gson/gson/2.11.0</bundle>
 
         <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version> <!-- Use the latest version -->
+            <version>${google.guava.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -23,6 +23,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>auto-clean</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>
@@ -178,6 +191,12 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version> <!-- Use the latest version -->
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <pkts.version>3.0.10</pkts.version>
         <protobuf.version>3.12.0</protobuf.version>
-        <google.guava.version>32.0.1-jre</google.guava.version>
+        <google.guava.version>31.1-jre</google.guava.version>
     </properties>
 
     <version>1.0.3-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <pkts.version>3.0.10</pkts.version>
         <protobuf.version>3.12.0</protobuf.version>
+        <google.guava.version>32.0.1-jre</google.guava.version>
     </properties>
 
     <version>1.0.3-SNAPSHOT</version>


### PR DESCRIPTION
The CI pipeline fails due to two build problems:

Rebuilding does not work without cleaning because mapstruct and lombok interfer with each others generated files

Feature deployment tests fails because it can not find a ONMS provided package during tests that are there during build time.