### PR TITLE
MPLUG-68 Resync: Missing node label in alarm proto

### DIFF
--- a/plugin/src/main/java/org/opennms/resync/EventHandler.java
+++ b/plugin/src/main/java/org/opennms/resync/EventHandler.java
@@ -107,6 +107,7 @@ public class EventHandler implements EventListener {
     public synchronized void createSession(final Source source,
                                            final String sessionId,
                                            final Duration timeout,
+                                           final String nodeLabel,
                                            final HashMap<String, Object> parameters) {
         if (this.sessions.containsKey(source)) {
             throw new IllegalStateException("session already exists for source: " + source);
@@ -115,6 +116,7 @@ public class EventHandler implements EventListener {
         this.sessions.put(source, Session.builder()
                 .sessionId(sessionId)
                 .timeout(timeout)
+                .nodeLabel(nodeLabel)
                 .parameters(Maps.transformValues(parameters, Object::toString))
                 .build());
 
@@ -192,14 +194,13 @@ public class EventHandler implements EventListener {
 
         final var session = this.sessions.get(source);
         session.lastEvent = Instant.now();
-
+        final String nodeLabel = session.nodeLabel;
         log.info("resync session {}: alarm - {} (id = {}, handler = {})", source, event, session.sessionId, System.identityHashCode(this));
 
         final var alarm = Resync.Alarm.newBuilder();
         alarm.setUei(event.getUei());
         alarm.setCount(1);
 
-        var nodeLabel = session.getParameters().get("nodeLabel");
         alarm.setNodeCriteria(Resync.NodeCriteria.newBuilder()
                         .setId(event.getNodeid())
                         .setNodeLabel(nodeLabel)
@@ -272,6 +273,8 @@ public class EventHandler implements EventListener {
 
         @NonNull
         private Duration timeout;
+        @NonNull
+        private String nodeLabel;
 
     }
 

--- a/plugin/src/main/java/org/opennms/resync/EventHandler.java
+++ b/plugin/src/main/java/org/opennms/resync/EventHandler.java
@@ -199,8 +199,10 @@ public class EventHandler implements EventListener {
         alarm.setUei(event.getUei());
         alarm.setCount(1);
 
+        var nodeLabel = session.getParameters().get("nodeLabel");
         alarm.setNodeCriteria(Resync.NodeCriteria.newBuilder()
                         .setId(event.getNodeid())
+                        .setNodeLabel(nodeLabel)
                 // TODO: Lookup node to provide more node info
         );
 

--- a/plugin/src/main/java/org/opennms/resync/EventHandler.java
+++ b/plugin/src/main/java/org/opennms/resync/EventHandler.java
@@ -194,6 +194,7 @@ public class EventHandler implements EventListener {
 
         final var session = this.sessions.get(source);
         session.lastEvent = Instant.now();
+
         log.info("resync session {}: alarm - {} (id = {}, handler = {})", source, event, session.sessionId, System.identityHashCode(this));
 
         final var alarm = Resync.Alarm.newBuilder();

--- a/plugin/src/main/java/org/opennms/resync/EventHandler.java
+++ b/plugin/src/main/java/org/opennms/resync/EventHandler.java
@@ -194,7 +194,6 @@ public class EventHandler implements EventListener {
 
         final var session = this.sessions.get(source);
         session.lastEvent = Instant.now();
-        final String nodeLabel = session.nodeLabel;
         log.info("resync session {}: alarm - {} (id = {}, handler = {})", source, event, session.sessionId, System.identityHashCode(this));
 
         final var alarm = Resync.Alarm.newBuilder();
@@ -203,7 +202,7 @@ public class EventHandler implements EventListener {
 
         alarm.setNodeCriteria(Resync.NodeCriteria.newBuilder()
                         .setId(event.getNodeid())
-                        .setNodeLabel(nodeLabel)
+                        .setNodeLabel(session.nodeLabel)
                 // TODO: Lookup node to provide more node info
         );
 
@@ -273,6 +272,7 @@ public class EventHandler implements EventListener {
 
         @NonNull
         private Duration timeout;
+
         @NonNull
         private String nodeLabel;
 

--- a/plugin/src/main/java/org/opennms/resync/TriggerService.java
+++ b/plugin/src/main/java/org/opennms/resync/TriggerService.java
@@ -156,7 +156,10 @@ public class TriggerService {
         final var parameters = new HashMap<String, Object>();
         parameters.putAll(config.getParameters());
         parameters.putAll(request.getParameters());
-
+        String nodeLabel = node.getLabel();
+        if (nodeLabel != null && !nodeLabel.isEmpty()) {
+            parameters.put("nodeLabel", nodeLabel);
+        }
         Duration timeout = coerce(request.getSessionTimeout() , config.getTimeout(), this.sessionTimeout);
 
         this.eventHandler.createSession(EventHandler.Source.builder()
@@ -224,6 +227,10 @@ public class TriggerService {
         final var parameters = new HashMap<String, Object>();
         parameters.putAll(config.getParameters());
         parameters.putAll(request.getParameters());
+        String nodeLabel = node.getLabel();
+        if (nodeLabel != null && !nodeLabel.isEmpty()) {
+            parameters.put("nodeLabel", nodeLabel);
+        }
 
         Duration timeout = coerce(request.getSessionTimeout() , config.getTimeout(), this.sessionTimeout);
 

--- a/plugin/src/main/java/org/opennms/resync/TriggerService.java
+++ b/plugin/src/main/java/org/opennms/resync/TriggerService.java
@@ -156,10 +156,7 @@ public class TriggerService {
         final var parameters = new HashMap<String, Object>();
         parameters.putAll(config.getParameters());
         parameters.putAll(request.getParameters());
-        String nodeLabel = node.getLabel();
-        if (nodeLabel != null && !nodeLabel.isEmpty()) {
-            parameters.put("nodeLabel", nodeLabel);
-        }
+
         Duration timeout = coerce(request.getSessionTimeout() , config.getTimeout(), this.sessionTimeout);
 
         this.eventHandler.createSession(EventHandler.Source.builder()
@@ -168,6 +165,7 @@ public class TriggerService {
                         .build(),
                 request.sessionId,
                 timeout,
+                node.getLabel(),
                 parameters);
         // TODO: This excepts on duplicate session? Should we wait?
 
@@ -227,10 +225,6 @@ public class TriggerService {
         final var parameters = new HashMap<String, Object>();
         parameters.putAll(config.getParameters());
         parameters.putAll(request.getParameters());
-        String nodeLabel = node.getLabel();
-        if (nodeLabel != null && !nodeLabel.isEmpty()) {
-            parameters.put("nodeLabel", nodeLabel);
-        }
 
         Duration timeout = coerce(request.getSessionTimeout() , config.getTimeout(), this.sessionTimeout);
 
@@ -245,6 +239,7 @@ public class TriggerService {
                                     .build(),
                             request.sessionId,
                             timeout,
+                            node.getLabel(),
                             parameters);
 
                     this.eventForwarder.sendNowSync(new EventBuilder()


### PR DESCRIPTION
The protobuf alarm messages send by the resync plugin lack the node label